### PR TITLE
Fix currency conversions and office selection

### DIFF
--- a/AssetTrackerApp.Tests/CurrencyConverterTests.cs
+++ b/AssetTrackerApp.Tests/CurrencyConverterTests.cs
@@ -1,0 +1,18 @@
+using Xunit;
+using AssetTrackerApp.Services;
+using AssetTrackerApp.Models;
+
+namespace AssetTrackerApp.Tests
+{
+    public class CurrencyConverterTests
+    {
+        [Fact]
+        public void Convert_SameCurrency_ReturnsSameValue()
+        {
+            decimal amount = 123.45m;
+            decimal converted = CurrencyConverter.Convert(amount, Currency.USD, Currency.USD, out decimal result);
+            Assert.Equal(amount, converted);
+            Assert.Equal(amount, result);
+        }
+    }
+}

--- a/AssetTrackerApp/ConsoleUI/ConsoleFormatter.cs
+++ b/AssetTrackerApp/ConsoleUI/ConsoleFormatter.cs
@@ -29,8 +29,12 @@ namespace AssetTrackerApp.ConsoleUI
             int ageInMonths = (int)((DateTime.Now - asset.PurchaseDate).TotalDays / 30.4375);
             int monthsLeft = LifeSpanInMonths - ageInMonths;
 
-            // Convert price
-            decimal localPrice = CurrencyConverter.ConvertTo(asset.Price.Amount, asset.Office.LocalCurrency, out decimal convertedAmount);
+            // Convert price from the asset's currency to the office's local currency
+            decimal localPrice = CurrencyConverter.Convert(
+                asset.Price.Amount,
+                asset.Price.Currency,
+                asset.Office.LocalCurrency,
+                out decimal convertedAmount);
             string priceDisplay = $"{Math.Round(convertedAmount, 2)} {asset.Office.LocalCurrency}";
 
             // If writing to console, apply color

--- a/AssetTrackerApp/ConsoleUI/Menu.cs
+++ b/AssetTrackerApp/ConsoleUI/Menu.cs
@@ -187,9 +187,19 @@ namespace AssetTrackerApp.ConsoleUI
                 return;
             }
 
-            var office = new Office(officeName, currency);
-            if (!offices.Any(o => o.Name.Equals(office.Name, StringComparison.OrdinalIgnoreCase)))
+            // Reuse existing office if available; otherwise create a new one and prompt for its currency
+            var office = offices.FirstOrDefault(o => o.Name.Equals(officeName, StringComparison.OrdinalIgnoreCase));
+            if (office == null)
             {
+                output.Write("Office currency (USD, EUR, SEK): ");
+                string? officeCurrencyInput = input.ReadLine()?.Trim();
+                if (!Enum.TryParse(officeCurrencyInput, true, out Currency officeCurrency))
+                {
+                    output.WriteLine("Invalid currency.");
+                    return;
+                }
+
+                office = new Office(officeName, officeCurrency);
                 offices.Add(office);
             }
 

--- a/AssetTrackerApp/Services/CurrencyConverter.cs
+++ b/AssetTrackerApp/Services/CurrencyConverter.cs
@@ -17,16 +17,38 @@ namespace AssetTrackerApp.Services
         private static Envelope exchangeRates = new Envelope();
 
         /// <summary>
-        /// Converts a value in EUR to the specified target currency.
+        /// Converts an amount between two currencies.
+        /// Internally converts via EUR since the ECB rates are EUR based.
+        /// </summary>
+        public static decimal Convert(decimal amount, Currency fromCurrency, Currency toCurrency, out decimal convertedValue)
+        {
+            // If currencies match no conversion is needed.
+            if (fromCurrency == toCurrency)
+            {
+                convertedValue = amount;
+                return convertedValue;
+            }
+
+            // Convert the source amount to EUR first.
+            decimal amountInEur = fromCurrency == Currency.EUR
+                ? amount
+                : amount / GetRateForCurrency(fromCurrency);
+
+            // Then convert EUR to the target currency.
+            decimal rateToTarget = toCurrency == Currency.EUR
+                ? 1m
+                : GetRateForCurrency(toCurrency);
+
+            convertedValue = amountInEur * rateToTarget;
+            return convertedValue;
+        }
+
+        /// <summary>
+        /// Backwards compatible wrapper for converting EUR to the specified target currency.
         /// </summary>
         public static decimal ConvertTo(decimal value, Currency targetCurrency, out decimal convertedValue)
         {
-            var rate = (targetCurrency == Currency.EUR)
-                ? 1m
-                : GetRateForCurrency(targetCurrency);
-
-            convertedValue = value * rate;
-            return convertedValue;
+            return Convert(value, Currency.EUR, targetCurrency, out convertedValue);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- convert prices between arbitrary currencies
- update asset formatting to use new conversion method
- prompt for office currency when creating new offices
- add unit test covering currency conversion logic

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415209b8f0832898efecf65534bee7