### PR TITLE
Fix menu test for new office currency prompt

### DIFF
--- a/AssetTrackerApp.Tests/MenuTests.cs
+++ b/AssetTrackerApp.Tests/MenuTests.cs
@@ -94,6 +94,7 @@ namespace AssetTrackerApp.Tests
             // Currency: "USD"
             // Purchase date: "2025-03-27"
             // Office: "TestOffice"
+            // Office currency supplied as "USD" since the office is new
             // Extra newline for the "Press Enter to return to menu..." prompt,
             // then "0" to exit, with an extra newline.
             string inputString =
@@ -105,6 +106,7 @@ namespace AssetTrackerApp.Tests
                 "USD\n" +
                 "2025-03-27\n" +
                 "TestOffice\n" +
+                "USD\n" +
                 "\n" +
                 "0\n\n";
             var input = new StringReader(inputString);


### PR DESCRIPTION
## Summary
- update the simulated input string in `Menu_Start_CreateAsset_AddsAsset` to include the office currency for new office creation
- clarify the test comment about supplying the office currency

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68415c6c00908328b65a5555f2bc3e88