### PR TITLE
Add AgeInMonths helper

### DIFF
--- a/AssetTrackerApp.Tests/AssetAgeTests.cs
+++ b/AssetTrackerApp.Tests/AssetAgeTests.cs
@@ -1,0 +1,21 @@
+using System;
+using Xunit;
+using AssetTrackerApp.Models;
+
+namespace AssetTrackerApp.Tests
+{
+    public class AssetAgeTests
+    {
+        [Fact]
+        public void AgeInMonths_ReturnsExpectedValue()
+        {
+            var office = new Office("Test", Currency.USD);
+            var price = new Price(1, Currency.USD);
+            var purchaseDate = DateTime.Now.AddMonths(-5);
+            var asset = new Computer(price, purchaseDate, "Brand", "Model", office);
+
+            int expected = (int)((DateTime.Now - purchaseDate).TotalDays / 30.4375);
+            Assert.Equal(expected, asset.AgeInMonths);
+        }
+    }
+}

--- a/AssetTrackerApp/ConsoleUI/ConsoleFormatter.cs
+++ b/AssetTrackerApp/ConsoleUI/ConsoleFormatter.cs
@@ -19,7 +19,8 @@ namespace AssetTrackerApp.ConsoleUI
                 return "⚠️  Cannot print null asset.";
             }
 
-            // Calculate age (unused result kept for potential future logic)
+            // Calculate age using the shared Asset helper. The result
+            // is used by PrintAsset when determining console colors.
 
             // Convert price from the asset's currency to the office's local currency
             CurrencyConverter.Convert(
@@ -69,8 +70,7 @@ namespace AssetTrackerApp.ConsoleUI
             }
 
             // Calculate age to determine color
-            int ageInMonths = (int)((DateTime.Now - asset.PurchaseDate).TotalDays / 30.4375);
-            int monthsLeft = LifeSpanInMonths - ageInMonths;
+            int monthsLeft = LifeSpanInMonths - asset.AgeInMonths;
 
             // If writing to console, apply color
             if (writer == Console.Out)

--- a/AssetTrackerApp/Models/Asset.cs
+++ b/AssetTrackerApp/Models/Asset.cs
@@ -45,6 +45,11 @@ namespace AssetTrackerApp.Models
         public Office Office { get; set; }
 
         /// <summary>
+        /// Calculates the age of the asset in whole months.
+        /// </summary>
+        public int AgeInMonths => (int)((DateTime.Now - PurchaseDate).TotalDays / 30.4375);
+
+        /// <summary>
         /// Constructs an asset with common properties.
         /// </summary>
         protected Asset(string brand, string model, DateTime purchaseDate, Price price, Office office)


### PR DESCRIPTION
## Summary
- add `AgeInMonths` helper on `Asset`
- use new helper in `ConsoleFormatter`
- clarify comment about age calculation
- add `AssetAgeTests` unit test

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684165036f448328bc1325a1b624a25c